### PR TITLE
[http] skip loggin health and metrics requests

### DIFF
--- a/http/http.go
+++ b/http/http.go
@@ -31,6 +31,19 @@ func New(params Params) (*fiber.App, error) {
 
 	app.Use(recover.New())
 	app.Use(fiberzap.New(fiberzap.Config{
+		Next: func(c *fiber.Ctx) bool {
+			p := c.Path()
+			// Normalize trailing slash
+			for len(p) > 1 && p[len(p)-1] == '/' {
+				p = p[:len(p)-1]
+			}
+			switch p {
+			case "/health", "/metrics", "/healthz", "/readyz", "/livez":
+				return true
+			default:
+				return false
+			}
+		},
 		SkipBody: func(c *fiber.Ctx) bool {
 			return c.Response().StatusCode() < 400
 		},


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Logging middleware now skips health and metrics endpoints (/health, /metrics, /healthz, /readyz, /livez) and normalizes trailing slashes so variants are treated the same.
  * No changes to endpoint behavior or response formats; application functionality remains unaffected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->