### PR TITLE
[http] unescape path by default

### DIFF
--- a/http/http.go
+++ b/http/http.go
@@ -28,6 +28,7 @@ func New(params Params) (*fiber.App, error) {
 		ProxyHeader:             "X-Forwarded-For",
 		ReadTimeout:             ReadTimeout,
 		TrustedProxies:          config.Proxies,
+		UnescapePath:            true,
 		WriteTimeout:            config.WriteTimeout,
 	})
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated request path handling so encoded paths are consistently interpreted as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->